### PR TITLE
Off-line analysis

### DIFF
--- a/irqstat
+++ b/irqstat
@@ -95,7 +95,7 @@ def filter_found(name, filter_list):
 
 
 def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
-                 zero, filters, file1, file2):
+                 zero, filters, file1, file2, overall):
     """Main I/O loop"""
     irqs = {}
     cpunodes = {}
@@ -103,11 +103,11 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
     loops = 0
     width = len('NODEXX')
 
-    if batch:
-        print "Running in batch mode"
-    else:
-        print ("interactive commands -- "
-               "t: view totals, 0-9: view node, any other key: quit")
+    if not file1 and batch:
+        print("Running in batch mode")
+    elif not file1:
+        print("interactive commands -- "
+              "t: view totals, 0-9: view node, any other key: quit\r")
 
     if file1:
         intr_filename = file1
@@ -195,9 +195,11 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
         for idx, irq in enumerate(rows):
             width = max(width, len(str(irq['sum'] - irq['oldsum'])))
 
-        print "" + '\r'
-        print time.ctime() + '\r'
-        print "IRQs / " + str(seconds) + " second(s)" + '\r'
+        if overall and loops > 0:
+            print("" + '\r')
+        if not file1 and (overall or loops > 0):
+            print(time.ctime() + '\r')
+            print("IRQs / " + str(seconds) + " second(s)" + '\r')
         fmtstr = ('IRQ# %' + str(width) + 's') % 'TOTAL'
 
         # node view header
@@ -215,7 +217,8 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
                 fmtstr += (' %' + str(width) + 's ') % node
 
         fmtstr += ' NAME'
-        print fmtstr + '\r'
+        if overall or loops > 0:
+            print(fmtstr + '\r')
 
         displayed_rows = 0
         for idx, irq in enumerate(rows):
@@ -250,7 +253,8 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
                     nodecnt = irq[nodesum] - irq[oldnodesum]
                     fmtstr += ((' %' + str(width) + 's ') % str(nodecnt))
             fmtstr += ' ' + irq['name']
-            print fmtstr + '\r'
+            if overall or loops > 0:
+                print(fmtstr + '\r')
             displayed_rows += 1
             if displayed_rows == rowcnt:
                 break
@@ -307,6 +311,8 @@ def main(args):
     parser.add_option("-F", "--file2", default="",
                       help="no monitoring. Compare the samples from two files "
                       "instead")
+    parser.add_option("-O", "--overall", action="store_true",
+                      help="print all-time stats at the beginning")
 
     options = parser.parse_args(args)[0]
 
@@ -330,6 +336,9 @@ def main(args):
             return -1
         options.iterations = 2
 
+    if options.file1 and not options.file2:
+        options.overall = True
+
     # Set the terminal to unbuffered, to catch a single keypress
     if not options.batch:
         out = sys.stdin.fileno()
@@ -345,7 +354,7 @@ def main(args):
         display_itop(options.batch, int(options.time), int(options.rows),
                      int(options.iterations), options.sort, options.totals,
                      options.node, options.zero, options.filter, options.file1,
-                     options.file2)
+                     options.file2, options.overall)
     except (KeyboardInterrupt, SystemExit):
         pass
     finally:

--- a/irqstat
+++ b/irqstat
@@ -95,7 +95,7 @@ def filter_found(name, filter_list):
 
 
 def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
-                 zero, filters, file1):
+                 zero, filters, file1, file2):
     """Main I/O loop"""
     irqs = {}
     cpunodes = {}
@@ -266,6 +266,10 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
         if loops == iterations:
             break
 
+        if file2 and loops == 1:
+            intr_filename = file2
+            continue
+
         # thread.interrupt_main() does not seem to interrupt a sleep, so break
         # it into tenth-of-a-second sleeps to improve user response time on exit
         for _ in range(0, seconds * 10):
@@ -300,6 +304,9 @@ def main(args):
                       help="include total rows")
     parser.add_option("-f", "--file1", default="",
                       help="read a file instead of /proc/interrupts")
+    parser.add_option("-F", "--file2", default="",
+                      help="no monitoring. Compare the samples from two files "
+                      "instead")
 
     options = parser.parse_args(args)[0]
 
@@ -317,6 +324,12 @@ def main(args):
         options.iterations = 1
         options.batch = True
 
+    if options.file2:
+        if not options.file1:
+            print("ERROR: --file2 requires --file1")
+            return -1
+        options.iterations = 2
+
     # Set the terminal to unbuffered, to catch a single keypress
     if not options.batch:
         out = sys.stdin.fileno()
@@ -331,7 +344,8 @@ def main(args):
     try:
         display_itop(options.batch, int(options.time), int(options.rows),
                      int(options.iterations), options.sort, options.totals,
-                     options.node, options.zero, options.filter, options.file1)
+                     options.node, options.zero, options.filter, options.file1,
+                     options.file2)
     except (KeyboardInterrupt, SystemExit):
         pass
     finally:

--- a/irqstat
+++ b/irqstat
@@ -182,7 +182,9 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
             if sort == 't':
                 return val['sum'] - val['oldsum']
             if sort == 'i':
-                return int(val['num'])
+                if val['num'].isdigit():
+                    return int(val['num'])
+                return sys.maxsize
             if sort == 'n':
                 return val['name']
         # reverse sort all IRQ count sorts

--- a/irqstat
+++ b/irqstat
@@ -48,21 +48,37 @@ def gen_numa():
     """Generate NUMA info"""
     cpunodes = {}
     numacores = {}
-    out = subprocess.Popen('numactl --hardware | grep cpus', shell=True,
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    errtxt = out.stderr.readline()
-    if errtxt:
-        print errtxt + '\r\n'
-        print "Is numactl installed?\r"
+    err_str = ""
+
+    try:
+        temp = subprocess.Popen(['numactl', '--hardware'],
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+        (output, error) = temp.communicate()
+        temp.wait()
+
+        if error:
+            print("NUMACTL ERROR:")
+            print(error)
+            exit(1)
+
+        output = output.split("\n")
+        for line in output:
+            arr = line.split()
+            if len(arr) < 3:
+                continue
+            if arr[0] == "node" and arr[2] == "cpus:":
+                node = arr[1]
+                numacores[node] = arr[3:]
+                for core in arr[3:]:
+                    cpunodes[core] = node
+                continue
+        return numacores, cpunodes
+    except OSError as err:
+        if err.errno == 2: # No such file or directory
+            err_str = " (is numactl installed?)"
+        print("OS ERROR: " + err.strerror + err_str)
         exit(1)
-    for line in out.stdout.readlines():
-        arr = line.split()
-        if arr[0] == "node" and arr[2] == "cpus:" and len(arr) > 3:
-            node = arr[1]
-            numacores[node] = arr[3:]
-            for core in arr[3:]:
-                cpunodes[core] = node
-    return numacores, cpunodes
 
 # input character, passed between threads
 INCHAR = ''

--- a/irqstat
+++ b/irqstat
@@ -115,52 +115,52 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
             KEYEVENT.clear()
             dispnode = INCHAR if INCHAR in numacores.keys() else '-1'
 
-        out = open('/proc/interrupts', 'r')
-        header = out.readline()
-        cpus = []
-        for name in header.split():
-            num = name[3:]
-            cpus.append(num)
+        with open('/proc/interrupts', 'r') as intr_file:
+            header = intr_file.readline()
+            cpus = []
+            for name in header.split():
+                num = name[3:]
+                cpus.append(num)
 
-            # Only query the numa information when something is missing.
-            # This is effectively the first time and when any disabled CPUs
-            # are enabled
-            if not num in cpunodes.keys():
-                numacores, cpunodes = gen_numa()
+                # Only query the numa information when something is missing.
+                # This is effectively the first time and when any disabled CPUs
+                # are enabled
+                if not num in cpunodes.keys():
+                    numacores, cpunodes = gen_numa()
 
-        for line in out.readlines():
-            vals = line.split()
-            irqnum = vals[0].rstrip(':')
+            for line in intr_file.readlines():
+                vals = line.split()
+                irqnum = vals[0].rstrip(':')
 
-            # Optionally exclude rows that are not an IRQ number
-            if totals is None:
-                try:
-                    num = int(irqnum)
-                except ValueError:
-                    continue
+                # Optionally exclude rows that are not an IRQ number
+                if totals is None:
+                    try:
+                        num = int(irqnum)
+                    except ValueError:
+                        continue
 
-            irq = {}
-            irq['cpus'] = [int(x) for x in vals[1:len(cpus)+1]]
-            irq['oldcpus'] = (irqs[irqnum]['cpus'] if irqnum in irqs
-                              else [0] * len(cpus))
-            irq['name'] = ' '.join(vals[len(cpus)+1:])
-            irq['oldsum'] = irqs[irqnum]['sum'] if irqnum in irqs else 0
-            irq['sum'] = sum(irq['cpus'])
-            irq['num'] = irqnum
+                irq = {}
+                irq['cpus'] = [int(x) for x in vals[1:len(cpus)+1]]
+                irq['oldcpus'] = (irqs[irqnum]['cpus'] if irqnum in irqs
+                                  else [0] * len(cpus))
+                irq['name'] = ' '.join(vals[len(cpus)+1:])
+                irq['oldsum'] = irqs[irqnum]['sum'] if irqnum in irqs else 0
+                irq['sum'] = sum(irq['cpus'])
+                irq['num'] = irqnum
 
-            for node in numacores.keys():
-                oldkey = 'oldsum' + node
-                key = 'sum' + node
-                irq[oldkey] = (irqs[irqnum][key] if irqnum in irqs
-                               and key in irqs[irqnum] else 0)
-                irq[key] = 0
+                for node in numacores.keys():
+                    oldkey = 'oldsum' + node
+                    key = 'sum' + node
+                    irq[oldkey] = (irqs[irqnum][key] if irqnum in irqs
+                                   and key in irqs[irqnum] else 0)
+                    irq[key] = 0
 
-            for idx, val in enumerate(irq['cpus']):
-                key = 'sum' + cpunodes[cpus[idx]]
-                irq[key] = irq[key] + val if key in irq else val
+                for idx, val in enumerate(irq['cpus']):
+                    key = 'sum' + cpunodes[cpus[idx]]
+                    irq[key] = irq[key] + val if key in irq else val
 
-            # save old
-            irqs[irqnum] = irq
+                # save old
+                irqs[irqnum] = irq
 
         def sort_func(val):
             """Sort output"""

--- a/irqstat
+++ b/irqstat
@@ -95,7 +95,7 @@ def filter_found(name, filter_list):
 
 
 def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
-                 zero, filters):
+                 zero, filters, file1):
     """Main I/O loop"""
     irqs = {}
     cpunodes = {}
@@ -109,13 +109,18 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
         print ("interactive commands -- "
                "t: view totals, 0-9: view node, any other key: quit")
 
+    if file1:
+        intr_filename = file1
+    else:
+        intr_filename = '/proc/interrupts'
+
     while True:
         # Grab the new display type at a time when nothing is in flux
         if KEYEVENT.isSet():
             KEYEVENT.clear()
             dispnode = INCHAR if INCHAR in numacores.keys() else '-1'
 
-        with open('/proc/interrupts', 'r') as intr_file:
+        with open(intr_filename, 'r') as intr_file:
             header = intr_file.readline()
             cpus = []
             for name in header.split():
@@ -291,6 +296,8 @@ def main(args):
                       "separated filters")
     parser.add_option("--totals", action="store_true",
                       help="include total rows")
+    parser.add_option("-f", "--file1", default="",
+                      help="read a file instead of /proc/interrupts")
 
     options = parser.parse_args(args)[0]
 
@@ -302,6 +309,11 @@ def main(args):
         options.filter = options.filter.split(',')
     else:
         options.filter = []
+
+    # If file is specified, no iterations
+    if options.file1:
+        options.iterations = 1
+        options.batch = True
 
     # Set the terminal to unbuffered, to catch a single keypress
     if not options.batch:
@@ -317,7 +329,7 @@ def main(args):
     try:
         display_itop(options.batch, int(options.time), int(options.rows),
                      int(options.iterations), options.sort, options.totals,
-                     options.node, options.zero, options.filter)
+                     options.node, options.zero, options.filter, options.file1)
     except (KeyboardInterrupt, SystemExit):
         pass
     finally:

--- a/irqstat
+++ b/irqstat
@@ -44,23 +44,28 @@ import threading
 KEYEVENT = threading.Event()
 
 
-def gen_numa():
+def gen_numa(numafile):
     """Generate NUMA info"""
     cpunodes = {}
     numacores = {}
     err_str = ""
 
     try:
-        temp = subprocess.Popen(['numactl', '--hardware'],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
-        (output, error) = temp.communicate()
-        temp.wait()
+        if not numafile:
+            temp = subprocess.Popen(['numactl', '--hardware'],
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+            (output, error) = temp.communicate()
+            temp.wait()
 
-        if error:
-            print("NUMACTL ERROR:")
-            print(error)
-            exit(1)
+            if error:
+                print("NUMACTL ERROR:")
+                print(error)
+                exit(1)
+        else:
+            numa_file = open(numafile, 'r')
+            output = numa_file.read()
+            numa_file.close()
 
         output = output.split("\n")
         for line in output:
@@ -74,10 +79,13 @@ def gen_numa():
                     cpunodes[core] = node
                 continue
         return numacores, cpunodes
-    except OSError as err:
+    except (OSError, IOError) as err:
         if err.errno == 2: # No such file or directory
-            err_str = " (is numactl installed?)"
-        print("OS ERROR: " + err.strerror + err_str)
+            if numafile:
+                err_str = " (does '" + numafile + "' exist?)"
+            else:
+                err_str = err.strerror + " (is numactl installed?)"
+        print("ERROR: " + err.strerror + err_str)
         exit(1)
 
 # input character, passed between threads
@@ -111,7 +119,7 @@ def filter_found(name, filter_list):
 
 
 def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
-                 zero, filters, file1, file2, overall):
+                 zero, filters, file1, file2, overall, numafile):
     """Main I/O loop"""
     irqs = {}
     cpunodes = {}
@@ -147,7 +155,7 @@ def display_itop(batch, seconds, rowcnt, iterations, sort, totals, dispnode,
                 # This is effectively the first time and when any disabled CPUs
                 # are enabled
                 if not num in cpunodes.keys():
-                    numacores, cpunodes = gen_numa()
+                    numacores, cpunodes = gen_numa(numafile)
 
             for line in intr_file.readlines():
                 vals = line.split()
@@ -329,6 +337,9 @@ def main(args):
                       "instead")
     parser.add_option("-O", "--overall", action="store_true",
                       help="print all-time stats at the beginning")
+    parser.add_option("-N", "--numafile", default="",
+                      help="read the NUMA info from a file, instead of "
+                      "calling numactl")
 
     options = parser.parse_args(args)[0]
 
@@ -370,7 +381,7 @@ def main(args):
         display_itop(options.batch, int(options.time), int(options.rows),
                      int(options.iterations), options.sort, options.totals,
                      options.node, options.zero, options.filter, options.file1,
-                     options.file2, options.overall)
+                     options.file2, options.overall, options.numafile)
     except (KeyboardInterrupt, SystemExit):
         pass
     finally:


### PR DESCRIPTION
I got to know this tool and immediately found it really useful! However, in addition to monitoring /proc/interrupts online, I often need to analyze "samples" of it. Basically, it can happen that I do "save" the content of /proc/interrupt in a file, then run a workload or a benchmark, then "save" /proc/interrupts again (in another file) and finally try to compare the numbers in the two files, to see how many and which one IRQs have happened during the activity of interest.

I felt like this tool can be adapted to do just that, without making it lose any of its current capabilities of doing online /proc/interrupts analysis. So here it is my attempt at doing that.