### PR TITLE
Fix unbuffered output on python3, plus some linting

### DIFF
--- a/irqstat
+++ b/irqstat
@@ -45,6 +45,17 @@ try:
 except ImportError:
     import _thread as thread
 
+class Unbuffered:
+    def __init__(self, stream):
+        self.stream = stream
+    def write(self, data):
+        self.stream.write(data)
+        self.stream.flush()
+    def writelines(self, datas):
+        self.stream.writelines(datas)
+        self.stream.flush()
+    def __getattr__(self, attr):
+        return getattr(self.stream, attr)
 
 KEYEVENT = threading.Event()
 
@@ -382,7 +393,7 @@ def main(args):
         # input thread
         thread.start_new_thread(wait_for_input, tuple())
     else:
-        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+        sys.stdout = Unbuffered(sys.stdout)
 
     try:
         display_itop(options.batch, int(options.time), int(options.rows),

--- a/irqstat
+++ b/irqstat
@@ -30,7 +30,6 @@ for node views, 't' for node totals
 
 __version__ = '1.0.1-pre'
 
-import os
 import sys
 import tty
 import termios
@@ -77,7 +76,7 @@ def gen_numa(numafile):
             if error:
                 print("NUMACTL ERROR:")
                 print(error)
-                exit(1)
+                sys.exit(1)
         else:
             numa_file = open(numafile, 'r')
             output = numa_file.read()
@@ -98,11 +97,11 @@ def gen_numa(numafile):
     except (OSError, IOError) as err:
         if err.errno == 2: # No such file or directory
             if numafile:
-                err_str = " (does '" + numafile + "' exist?)"
+                err_str = " (does '" + numafile + "' exist?)\r"
             else:
-                err_str = err.strerror + " (is numactl installed?)"
+                err_str = err.strerror + " (is numactl installed?)\r"
         print("ERROR: " + err.strerror + err_str)
-        exit(1)
+        sys.exit(1)
 
 # input character, passed between threads
 INCHAR = ''


### PR DESCRIPTION
When trying to run `irqstat -b` with python3, I've been facing this error:

    Traceback (most recent call last):
      File "/usr/bin/irqstat", line 401, in <module>
        sys.exit(main(sys.argv))
      File "/usr/bin/irqstat", line 385, in main
        sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
      File "/usr/lib64/python3.8/os.py", line 1023, in fdopen
        return io.open(fd, *args, **kwargs)
    ValueError: can't have unbuffered text I/O

This pull requests fixes that.

While there, let's also take care of some low-hanging pylint suggestions.